### PR TITLE
Adjust TV folder card width

### DIFF
--- a/MKV Renamer/Program.cs
+++ b/MKV Renamer/Program.cs
@@ -745,9 +745,9 @@ namespace MKVRenamer
                 {
                     topBar.ColumnCount = 3;
                     topBar.RowCount = 1;
-                    topBar.ColumnStyles.Add(new WinForms.ColumnStyle(WinForms.SizeType.Percent, 45F));
+                    topBar.ColumnStyles.Add(new WinForms.ColumnStyle(WinForms.SizeType.Percent, 40F));
                     topBar.ColumnStyles.Add(new WinForms.ColumnStyle(WinForms.SizeType.Percent, 35F));
-                    topBar.ColumnStyles.Add(new WinForms.ColumnStyle(WinForms.SizeType.Percent, 20F));
+                    topBar.ColumnStyles.Add(new WinForms.ColumnStyle(WinForms.SizeType.Percent, 25F));
                     topBar.RowStyles.Add(new WinForms.RowStyle(WinForms.SizeType.Percent, 100F));
                     topBar.SetCellPosition(cardFolder, new WinForms.TableLayoutPanelCellPosition(0, 0));
                     topBar.SetCellPosition(cardSeries, new WinForms.TableLayoutPanelCellPosition(1, 0));


### PR DESCRIPTION
## Summary
- reduce the TV top bar layout width allocated to the folder card so the seasons button stays visible

## Testing
- ❌ `dotnet build` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf99ef85008330ab4400c4b9ee505e